### PR TITLE
Fix installation failures with modern setuptools and transformers 5.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,6 @@ ftfy
 func_timeout
 accelerate>=0.25.0
 diffusers>=0.30.1,<=0.31.0
-transformers>=4.46.2
+transformers>=4.46.2,<5
+modelscope
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from setuptools import setup, find_packages
-import pkg_resources
 
 # Path to the requirements file
 requirements_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
@@ -8,7 +7,10 @@ requirements_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
 # Read the requirements from the requirements file
 if os.path.exists(requirements_path):
     with open(requirements_path, 'r') as f:
-        install_requires = [str(r) for r in pkg_resources.parse_requirements(f)]
+        install_requires = [
+            line.strip() for line in f
+            if line.strip() and not line.startswith("#")
+        ]
 else:
     install_requires = []
 


### PR DESCRIPTION
Three issues prevent clean installation:

1. setup.py imports pkg_resources, which was deprecated in setuptools 67+ and removed in setuptools 82+. This breaks build isolation in uv (now) and will break pip when it updates its bundled setuptools. Replaced with plain text file reading — the requirements are already valid pip strings.

2. transformers>=4.46.2 has no upper bound. transformers 5.x removed PretrainedConfig from transformers.modeling_utils, breaking the StepVideo text encoder import. Added <5 cap.

3. modelscope and matplotlib are imported at runtime but not declared in requirements.txt. Added both.

Made-with: Cursor